### PR TITLE
WIP: Add Metadata Map to Room for easier extensibility

### DIFF
--- a/lib/flutter_firebase_chat_core.dart
+++ b/lib/flutter_firebase_chat_core.dart
@@ -1,3 +1,4 @@
 library flutter_firebase_chat_core;
 
 export 'src/firebase_chat_core.dart';
+export 'src/util.dart'; // exporting util to allow for extensibility of firebase_chat_core.

--- a/lib/src/firebase_chat_core.dart
+++ b/lib/src/firebase_chat_core.dart
@@ -25,6 +25,7 @@ class FirebaseChatCore {
     String? imageUrl,
     required String name,
     required List<types.User> users,
+    Map<String, dynamic>? metadata,
   }) async {
     if (firebaseUser == null) return Future.error('User does not exist');
 
@@ -36,6 +37,7 @@ class FirebaseChatCore {
       'name': name,
       'type': 'group',
       'userIds': roomUsers.map((u) => u.id).toList(),
+      'metadata': metadata
     });
 
     return types.Room(
@@ -44,11 +46,15 @@ class FirebaseChatCore {
       name: name,
       type: types.RoomType.group,
       users: roomUsers,
+      metadata: metadata,
     );
   }
 
   /// Creates a normal room for 2 people
-  Future<types.Room> createRoom(types.User otherUser) async {
+  Future<types.Room> createRoom(
+    types.User otherUser,
+    Map<String, dynamic>? metadata,
+  ) async {
     if (firebaseUser == null) return Future.error('User does not exist');
 
     final query = await FirebaseFirestore.instance
@@ -79,12 +85,14 @@ class FirebaseChatCore {
       'name': null,
       'type': 'direct',
       'userIds': users.map((u) => u.id).toList(),
+      'metadata': metadata
     });
 
     return types.Room(
       id: room.id,
       type: types.RoomType.direct,
       users: users,
+      metadata: metadata,
     );
   }
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -21,6 +21,7 @@ Future<List<types.Room>> processRoomsQuery(
     var name = doc.get('name') as String?;
     final type = doc.get('type') as String;
     final userIds = doc.get('userIds') as List<dynamic>;
+    final metadata = doc.get('metadata') as Map<String, dynamic>?;
 
     final users = await Future.wait(
       userIds.map(
@@ -48,6 +49,7 @@ Future<List<types.Room>> processRoomsQuery(
       name: name,
       type: type == 'direct' ? types.RoomType.direct : types.RoomType.group,
       users: users,
+      metadata: metadata,
     );
 
     return room;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,13 @@ dependencies:
     sdk: flutter
   cloud_firestore: ^1.0.2
   firebase_auth: ^1.0.1
-  flutter_chat_types: ^2.0.7
   meta: ^1.3.0
+
+dependency_overrides:
+  flutter_chat_types:
+    git:
+      url: https://github.com/alihen/flutter_chat_types.git
+      ref: c307eb58bed4e1f96fda8c6156a3340c609a3027
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Context

This `flutter_firebase_chat_core` dependency is a great start on implementing chat, but the current room concept can be quite basic and cannot be extended upon easily without forking and diverging away from the core implementation to suit a specific use-case.

This introduces a Map to the `Room` object, called `metadata`, which allows the user to add additional metadata to the room that allows wider usage of the `flutter_firebase_chat_core` without forking it for specific needs.

I've created the other Pull Request for this feature here: https://github.com/flyerhq/flutter_chat_types/pull/7

### Possible Risks

During building this, I found that exposing `util.dart` to be useful too, as it allows users to make use of helper methods like `processRoomsQuery` when writing custom Firestore get methods:

```
Stream<List<chatTypes.Room>> activeRooms() {
    User firebaseUser = FirebaseAuth.instance.currentUser;
    if (firebaseUser == null) return const Stream.empty();

    return FirebaseFirestore.instance
        .collection('rooms')
        .where('userIds', arrayContains: firebaseUser.uid)
        .where('metadata.is_active', isEqualTo: true)  // using metadata and an additional where clause
        .snapshots()
        .asyncMap((query) => processRoomsQuery(firebaseUser, query));  // using processRoomsQuery from util.dart
}
```
I'm not sure if exposing `util.dart` in the export is the most elegant solution here, but I do think that having access to `processRoomsQuery` and allowing users to write their own custom queries is a good idea.


### ToDo

- [x] Get https://github.com/flyerhq/flutter_chat_types/pull/7 merged in
- [x] Decide on how to expose util methods like `processRoomsQuery`