### PR TITLE
Removing user from FireStore

### DIFF
--- a/lib/src/firebase_chat_core.dart
+++ b/lib/src/firebase_chat_core.dart
@@ -124,6 +124,11 @@ class FirebaseChatCore {
     });
   }
 
+  /// Removes [types.User] collection in Firebase
+  Future<void> deleteUserFromFirestore(String userId) async {
+    await FirebaseFirestore.instance.collection('users').doc(userId).delete();
+  }
+
   /// Returns a stream of messages from Firebase for a given room
   Stream<List<types.Message>> messages(types.Room room) {
     return FirebaseFirestore.instance


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_firebase_chat_core/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds a function which receives the user's id and delete it from the _users_ collection.

### Why is it needed?

When the user deletes its account, the chat user instance should be deleted too.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
