### PR TITLE
Update a room updatedAt when a new message is sent

### DIFF
--- a/lib/src/firebase_chat_core.dart
+++ b/lib/src/firebase_chat_core.dart
@@ -353,6 +353,13 @@ class FirebaseChatCore {
       await getFirebaseFirestore()
           .collection('${config.roomsCollectionName}/$roomId/messages')
           .add(messageMap);
+      
+      await getFirebaseFirestore()
+          .collection('${config.roomsCollectionName}')
+          .doc('$roomId')
+          .update({
+            "updatedAt": FieldValue.serverTimestamp(),
+      });
     }
   }
 


### PR DESCRIPTION
The field updatedAt of a room doesn't get updated when a new message is sent, which causes FirebaseChatCore.instance.rooms(orderByUpdatedAt: true) not to work as expected.
