### PR TITLE
edit create room to make one read to the database, and not read all rooms and users in the rooms

### DIFF
--- a/lib/src/firebase_chat_core.dart
+++ b/lib/src/firebase_chat_core.dart
@@ -104,29 +104,51 @@ class FirebaseChatCore {
 
     if (fu == null) return Future.error('User does not exist');
 
+    //auto sort the two users id to always make the same array for both users
+    //this make it to easy to find the room if exist and make one read only
+    final userIds = [fu.uid, otherUser.id]..sort();
+
     final query = await getFirebaseFirestore()
         .collection(config.roomsCollectionName)
-        .where('userIds', arrayContains: fu.uid)
+        .where('userIds', isEqualTo: userIds)
+        .limit(1)
         .get();
 
-    final rooms = await processRoomsQuery(
-      fu,
-      getFirebaseFirestore(),
-      query,
-      config.usersCollectionName,
-    );
-
-    try {
-      return rooms.firstWhere((room) {
-        if (room.type == types.RoomType.group) return false;
-
-        final userIds = room.users.map((u) => u.id);
-        return userIds.contains(fu.uid) && userIds.contains(otherUser.id);
-      });
-    } catch (e) {
-      // Do nothing if room does not exist
-      // Create a new room instead
+    //check if the room is exist
+    if (query.docs.isNotEmpty) {
+      final room = (await processRoomsQuery(
+        fu,
+        getFirebaseFirestore(),
+        query,
+        config.usersCollectionName,
+      )).first;
+      return room;
     }
+    //to support the old chats created without sort the array
+    // try to check the room by revers users ids array
+    final queryForOldRoom = await getFirebaseFirestore()
+        .collection(config.roomsCollectionName)
+        .where('userIds', isEqualTo: userIds.reversed.toList())
+        .limit(1)
+        .get();
+
+    //check if the room is exist
+    if (queryForOldRoom.docs.isNotEmpty) {
+      //we can edit the user ids array here to be with the new way
+      // but it will need user to have permission to edit the room
+      // await getFirebaseFirestore().collection(config.roomsCollectionName)
+      //     .doc(queryForOldRoom.docs.first.id).update({'userIds': userIds});
+
+      final room = (await processRoomsQuery(
+        fu,
+        getFirebaseFirestore(),
+        queryForOldRoom,
+        config.usersCollectionName,
+      )).first;
+      return room;
+    }
+
+
 
     final currentUser = await fetchUser(
       getFirebaseFirestore(),
@@ -136,7 +158,8 @@ class FirebaseChatCore {
 
     final users = [types.User.fromJson(currentUser), otherUser];
 
-    final room = await getFirebaseFirestore()
+    // create new room with sorted users ids array
+    final createdRoom = await getFirebaseFirestore()
         .collection(config.roomsCollectionName)
         .add({
       'createdAt': FieldValue.serverTimestamp(),
@@ -145,12 +168,12 @@ class FirebaseChatCore {
       'name': null,
       'type': types.RoomType.direct.toShortString(),
       'updatedAt': FieldValue.serverTimestamp(),
-      'userIds': users.map((u) => u.id).toList(),
+      'userIds': userIds,
       'userRoles': null,
     });
 
     return types.Room(
-      id: room.id,
+      id: createdRoom.id,
       metadata: metadata,
       type: types.RoomType.direct,
       users: users,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_firebase_chat_core/blob/main/CONTRIBUTING.md
-->

### What does it do?

it make one call to the db to find the exist room, the old code was read all the user rooms and all the users in this rooms, this code just read one room if it exist,
this will add the ability to use this function any where i user profile and open the chat with his id

### Why is it needed?

the function create room was read all the user rooms, and read all the users in this rooms, too much reads with no reason

### How to test it?

By open an old room with this code, and create new room .

### Related issues/PRs

https://github.com/flyerhq/flutter_firebase_chat_core/issues/67#issue-1180562356

i found this one, but i make this edit for my app  with other customisation, i may make PR for some of them in the future.

