### PR TITLE
Make group creator admin

### DIFF
--- a/lib/src/firebase_chat_core.dart
+++ b/lib/src/firebase_chat_core.dart
@@ -54,6 +54,7 @@ class FirebaseChatCore {
     Map<String, dynamic>? metadata,
     required String name,
     required List<types.User> users,
+    bool creatorIsAdmin = true
   }) async {
     if (firebaseUser == null) return Future.error('User does not exist');
 
@@ -61,6 +62,7 @@ class FirebaseChatCore {
       getFirebaseFirestore(),
       firebaseUser!.uid,
       config.usersCollectionName,
+      role: creatorIsAdmin ? types.Role.admin.toShortString() : null
     );
 
     final roomUsers = [types.User.fromJson(currentUser)] + users;
@@ -83,6 +85,8 @@ class FirebaseChatCore {
         },
       ),
     });
+    
+    print(roomUsers.map((e) => e.role.toString()));
 
     return types.Room(
       id: room.id,

--- a/lib/src/firebase_chat_core.dart
+++ b/lib/src/firebase_chat_core.dart
@@ -54,7 +54,7 @@ class FirebaseChatCore {
     Map<String, dynamic>? metadata,
     required String name,
     required List<types.User> users,
-    bool creatorIsAdmin = true
+    types.Role creatorRole = types.Role.admin
   }) async {
     if (firebaseUser == null) return Future.error('User does not exist');
 
@@ -62,7 +62,7 @@ class FirebaseChatCore {
       getFirebaseFirestore(),
       firebaseUser!.uid,
       config.usersCollectionName,
-      role: creatorIsAdmin ? types.Role.admin.toShortString() : null
+      role: creatorRole.toShortString()
     );
 
     final roomUsers = [types.User.fromJson(currentUser)] + users;
@@ -85,8 +85,6 @@ class FirebaseChatCore {
         },
       ),
     });
-    
-    print(roomUsers.map((e) => e.role.toString()));
 
     return types.Room(
       id: room.id,


### PR DESCRIPTION

### What does it do?
Sets role admin for currentUser when the createGroupRoom method is called, using an optional variable "creatorRole"

Describe the technical changes you did.

### Why is it needed?

When creating a group, the current user is automatically added as user to the group. however, it MAY be desired, that the current user is marked Admin (that is, given the role admin) .

This update makes this possible, the current user is marked as admin. a different role can be set using the variable 'creatorRole' passed to the 'createGroupRoom' method.

### How to test it?
create a group room using the createGroupRoom method and check the role of the current user, the value should be admin

### Related issues/PRs
none
