### PR TITLE
Add  PartialVideo message type on sendMessage function

### DIFF
--- a/lib/src/firebase_chat_core.dart
+++ b/lib/src/firebase_chat_core.dart
@@ -363,6 +363,12 @@ class FirebaseChatCore {
         id: '',
         partialText: partialMessage,
       );
+    } else if (partialMessage is types.PartialVideo) {
+      message = types.VideoMessage.fromPartial(
+        author: types.User(id: firebaseUser!.uid),
+        id: '',
+        partialVideo: partialMessage,
+      );
     }
 
     if (message != null) {


### PR DESCRIPTION
Hi there. 

I just add PartialVideo type message when hit sendMessage PartialVideo. 
Later on user need to define the videoMessageBuilder or someone need to handle video on flutter_chat_ui package. 

Thankyou